### PR TITLE
ci: add lint step to CI workflow and improve documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run linter
+        run: npm run lint
+
   # scan:
   #   needs: lint-and-test
   #   if: ${{ github.event_name == 'pull_request' && github.event.repository.private == false }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Arc Multichain Wallet
+
+Thank you for your interest in contributing to Arc Multichain Wallet! We welcome contributions from the community.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork locally
+3. Create a new branch for your changes
+4. Make your changes
+5. Submit a pull request
+
+## Development Setup
+
+```bash
+# Install dependencies
+npm install
+
+# Copy environment variables
+cp .env.example .env.local
+
+# Start local Supabase (requires Docker)
+npx supabase start
+npx supabase db push
+
+# Start the development server
+npm run dev
+```
+
+## Pull Request Process
+
+1. Ensure your code follows the existing code style and passes linting (`npm run lint`).
+2. Update documentation if your changes affect the public API or user-facing behavior.
+3. Write clear, descriptive commit messages using [Conventional Commits](https://www.conventionalcommits.org/).
+4. Keep pull requests focused — one feature or fix per PR.
+5. Include a clear description of what your PR does and why.
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. We are committed to providing a welcoming and inclusive experience for everyone.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/lib/deposit.ts
+++ b/lib/deposit.ts
@@ -46,8 +46,24 @@ export async function handleDeposit(
     return { error: 'Missing amount' };
   }
 
-  // TODO: Integrate Circle Paymaster API for gas abstraction
-  // Placeholder for deposit logic with gas paid in USDC
+  /**
+   * Circle Paymaster API Integration (Planned)
+   *
+   * The Circle Paymaster API enables gas abstraction for ERC-4337 UserOperations,
+   * allowing users to pay transaction fees in USDC instead of native gas tokens.
+   *
+   * Planned integration steps:
+   * 1. Construct the deposit UserOperation for the target chain.
+   * 2. Call the Circle Paymaster API (`POST /paymaster/policy/{policyId}/sponsor`)
+   *    to obtain a sponsored `paymasterAndData` payload.
+   * 3. Sign the sponsored UserOperation with the user's developer-controlled wallet.
+   * 4. Submit the signed UserOperation to the bundler for on-chain execution.
+   *
+   * This will replace the mock deposit logic below with actual on-chain transactions
+   * where gas fees are transparently covered in USDC via the Circle Paymaster.
+   *
+   * @see https://developers.circle.com/paymaster/overview
+   */
   const depositResult = {
     txHash: 'mock-tx-hash',
     gatewayWalletAddress: 'mock-gateway-wallet-address',


### PR DESCRIPTION
## Summary

This PR adds the missing lint step to the CI workflow and improves project documentation.

### Changes

1. **CI workflow** — Added `npm run lint` step after dependency installation. The job is named `lint-and-test` but was only installing dependencies without running the linter.
2. **deposit.ts documentation** — Replaced the sparse TODO comment for Circle Paymaster API integration with a detailed JSDoc comment explaining the planned integration steps.
3. **CONTRIBUTING.md** — Added contribution guidelines covering development setup, PR process, and coding standards.

### Why

- The CI lint-and-test job should actually run the linter to catch issues before merge
- Detailed documentation on planned integrations helps contributors understand the roadmap
- Contribution guidelines reduce friction for new contributors