### PR TITLE
fix: remove hardcoded RPC API key and add to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key
 # Circle
 CIRCLE_API_KEY=your-circle-api-key
 CIRCLE_ENTITY_SECRET=your-circle-entity-secret
+ARC_TESTNET_RPC_KEY=

--- a/lib/circle/gateway-sdk.ts
+++ b/lib/circle/gateway-sdk.ts
@@ -39,7 +39,10 @@ import {
 export const GATEWAY_WALLET_ADDRESS = "0x0077777d7EBA4688BDeF3E311b846F25870A19B9";
 export const GATEWAY_MINTER_ADDRESS = "0x0022222ABE238Cc2C7Bb1f21003F0a260052475B";
 
-const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY || 'c0ca2582063a5bbd5db2f98c139775e982b16919';
+const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY;
+if (!arcRpcKey) {
+  throw new Error("ARC_TESTNET_RPC_KEY environment variable is not set");
+}
 
 export const arcTestnet = {
   id: 5042002,


### PR DESCRIPTION
## Problem

A real API key is hardcoded as a fallback value in `lib/circle/gateway-sdk.ts`:

```ts
const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY || 'c0ca2582063a5bbd5db2f98c139775e982b16919';
```

Since this is an open source repository, the key is publicly visible to anyone. Additionally, `ARC_TESTNET_RPC_KEY` was missing from `.env.example`, so developers had no indication this variable was required.

## Fix

```diff
- const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY || 'c0ca2582063a5bbd5db2f98c139775e982b16919';
+ const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY;
+ if (!arcRpcKey) {
+   throw new Error("ARC_TESTNET_RPC_KEY environment variable is not set");
+ }
```

Also added `ARC_TESTNET_RPC_KEY=` to `.env.example` so developers know to set it.

## Impact

- **Security:** Exposed API key removed from source code
- **DX:** Developers get a clear error message if the variable is missing
- **Risk:** Low — anyone running the app must set the env variable explicitly