### PR TITLE
fix: validate amount with isFinite and fix float precision in USDC conversion

### DIFF
--- a/app/api/gateway/deposit/route.ts
+++ b/app/api/gateway/deposit/route.ts
@@ -58,6 +58,14 @@ export async function POST(req: NextRequest) {
     // Convert amount to bigint (amount should be in USDC, multiply by 1_000_000)
     const parsedAmount = parseFloat(amount);
 
+    // Validate amount is a finite number
+    if (!isFinite(parsedAmount)) {
+      return NextResponse.json(
+        { error: "Amount must be a valid number" },
+        { status: 400 }
+      );
+    }
+
     // Validate if amount is positive
     if (parsedAmount <= 0) {
       return NextResponse.json(
@@ -74,7 +82,9 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    const amountInAtomicUnits = BigInt(Math.floor(parsedAmount * 1_000_000));
+    // Parse integer and decimal parts separately to avoid float precision issues
+    const [intPart, decPart = ""] = parsedAmount.toFixed(6).split(".");
+    const amountInAtomicUnits = BigInt(intPart) * 1_000_000n + BigInt(decPart);
 
     // Get the user's multichain SCA wallet
     const { data: wallets, error: walletError } = await supabase

--- a/app/api/gateway/deposit/route.ts
+++ b/app/api/gateway/deposit/route.ts
@@ -55,16 +55,15 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Convert amount to bigint (amount should be in USDC, multiply by 1_000_000)
-    const parsedAmount = parseFloat(amount);
-
-    // Validate amount is a finite number
-    if (!isFinite(parsedAmount)) {
+    if (typeof amount !== "string" || !/^\d+(?:\.\d{1,6})?$/.test(amount)) {
       return NextResponse.json(
-        { error: "Amount must be a valid number" },
+        { error: "Amount must be a valid USDC amount" },
         { status: 400 }
       );
     }
+
+    // Convert amount to bigint (amount should be in USDC, multiply by 1_000_000)
+    const parsedAmount = parseFloat(amount);
 
     // Validate if amount is positive
     if (parsedAmount <= 0) {
@@ -83,8 +82,9 @@ export async function POST(req: NextRequest) {
     }
 
     // Parse integer and decimal parts separately to avoid float precision issues
-    const [intPart, decPart = ""] = parsedAmount.toFixed(6).split(".");
-    const amountInAtomicUnits = BigInt(intPart) * 1_000_000n + BigInt(decPart);
+    const [intPart, decPart = ""] = amount.split(".");
+    const paddedDec = decPart.padEnd(6, "0");
+    const amountInAtomicUnits = BigInt(intPart) * 1_000_000n + BigInt(paddedDec);
 
     // Get the user's multichain SCA wallet
     const { data: wallets, error: walletError } = await supabase

--- a/app/api/gateway/transfer/route.ts
+++ b/app/api/gateway/transfer/route.ts
@@ -73,14 +73,14 @@ export async function POST(req: NextRequest) {
     // Same-chain transfers are allowed (withdrawal from Gateway to wallet)
     // Cross-chain transfers will go through Gateway's burn/mint process
 
-    const parsedAmount = parseFloat(amount);
-
-    if (!isFinite(parsedAmount)) {
+    if (typeof amount !== "string" || !/^\d+(?:\.\d{1,6})?$/.test(amount)) {
       return NextResponse.json(
-        { error: "Amount must be a valid number" },
+        { error: "Amount must be a valid USDC amount" },
         { status: 400 }
       );
     }
+
+    const parsedAmount = parseFloat(amount);
 
     if (parsedAmount <= 0) {
       return NextResponse.json(
@@ -90,8 +90,9 @@ export async function POST(req: NextRequest) {
     }
 
     // Parse integer and decimal parts separately to avoid float precision issues
-    const [intPart, decPart = ""] = parsedAmount.toFixed(6).split(".");
-    const amountInAtomicUnits = BigInt(intPart) * 1_000_000n + BigInt(decPart);
+    const [intPart, decPart = ""] = amount.split(".");
+    const paddedDec = decPart.padEnd(6, "0");
+    const amountInAtomicUnits = BigInt(intPart) * 1_000_000n + BigInt(paddedDec);
 
     // Get the user's multichain SCA wallet
     const { data: wallets, error: walletError } = await supabase

--- a/app/api/gateway/transfer/route.ts
+++ b/app/api/gateway/transfer/route.ts
@@ -73,7 +73,25 @@ export async function POST(req: NextRequest) {
     // Same-chain transfers are allowed (withdrawal from Gateway to wallet)
     // Cross-chain transfers will go through Gateway's burn/mint process
 
-    const amountInAtomicUnits = BigInt(Math.floor(parseFloat(amount) * 1_000_000));
+    const parsedAmount = parseFloat(amount);
+
+    if (!isFinite(parsedAmount)) {
+      return NextResponse.json(
+        { error: "Amount must be a valid number" },
+        { status: 400 }
+      );
+    }
+
+    if (parsedAmount <= 0) {
+      return NextResponse.json(
+        { error: "Amount must be greater than 0" },
+        { status: 400 }
+      );
+    }
+
+    // Parse integer and decimal parts separately to avoid float precision issues
+    const [intPart, decPart = ""] = parsedAmount.toFixed(6).split(".");
+    const amountInAtomicUnits = BigInt(intPart) * 1_000_000n + BigInt(decPart);
 
     // Get the user's multichain SCA wallet
     const { data: wallets, error: walletError } = await supabase


### PR DESCRIPTION
## Problem

Two related bugs in `deposit/route.ts` and `transfer/route.ts`:

### 1. NaN bypasses validation and crashes BigInt

```ts
const parsedAmount = parseFloat(amount); // "abc" → NaN
if (parsedAmount <= 0) ...               // NaN <= 0 is false — check passes!
BigInt(Math.floor(NaN * 1_000_000))      // RangeError crash
```

### 2. Float precision loss in financial math

```ts
BigInt(Math.floor(parseFloat("0.1") * 1_000_000)) // → 99999, not 100000
```

IEEE 754 float multiplication causes precision loss for USDC amounts.

## Fix

```diff
+ if (!isFinite(parsedAmount)) {
+   return NextResponse.json({ error: "Amount must be a valid number" }, { status: 400 });
+ }

- const amountInAtomicUnits = BigInt(Math.floor(parsedAmount * 1_000_000));
+ const [intPart, decPart = ""] = parsedAmount.toFixed(6).split(".");
+ const amountInAtomicUnits = BigInt(intPart) * 1_000_000n + BigInt(decPart);
```

`toFixed(6)` produces a stable string like `"1.100000"` which we split and recombine as integer arithmetic — no float multiplication, no precision loss.

## Impact

- **Correctness:** Prevents RangeError crash on invalid input
- **Financial precision:** USDC amounts now convert correctly (e.g. `0.1 USDC → 100000` not `99999`)
- **Risk:** Low — input validation added, conversion logic made more precise