### PR TITLE
fix: prevent null crash on entityName.trim() with type check

### DIFF
--- a/app/api/wallet-set/route.ts
+++ b/app/api/wallet-set/route.ts
@@ -24,9 +24,9 @@ export async function PUT(req: NextRequest) {
   try {
     const { entityName } = await req.json();
 
-    if (!entityName.trim()) {
+    if (typeof entityName !== "string" || !entityName.trim()) {
       return NextResponse.json(
-        { error: "entityName is required" },
+        { error: "entityName is required and must be a non-empty string" },
         { status: 400 }
       );
     }


### PR DESCRIPTION
## Problem

In `app/api/wallet-set/route.ts`, if `entityName` is missing from the request body, `.trim()` throws a `TypeError` before validation can run:

```ts
const { entityName } = await req.json();

if (!entityName.trim()) {  // 💥 TypeError if entityName is undefined
  return NextResponse.json({ error: "entityName is required" }, { status: 400 });
}
```

This causes an unhandled 500 instead of returning a proper 400 response.

## Fix

Added a type check before calling `.trim()`:

```diff
- if (!entityName.trim()) {
+ if (typeof entityName !== "string" || !entityName.trim()) {
    return NextResponse.json(
-     { error: "entityName is required" },
+     { error: "entityName is required and must be a non-empty string" },
      { status: 400 }
    );
  }
```

The `typeof` check safely handles `undefined`, `null`, numbers, and any other non-string value before `.trim()` is ever called.

## Impact

- **Correctness:** Returns proper 400 instead of unhandled 500
- **Risk:** Low — additive validation, no breaking changes