### PR TITLE
fix(arc-testnet): correct native token symbol, decimals, and explorer URL

### DIFF
--- a/lib/chain-config.ts
+++ b/lib/chain-config.ts
@@ -28,7 +28,7 @@ export const CHAIN_NAMES: Record<SupportedChain, string> = {
 };
 
 export const NATIVE_TOKENS: Record<string, string> = {
-  arcTestnet: "ARC",
+  arcTestnet: "USDC",
   avalancheFuji: "AVAX",
   baseSepolia: "ETH",
 };

--- a/lib/circle/gateway-sdk.ts
+++ b/lib/circle/gateway-sdk.ts
@@ -44,12 +44,12 @@ const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY || 'c0ca2582063a5bbd5db2f98c13
 export const arcTestnet = {
   id: 5042002,
   name: 'Arc Testnet',
-  nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+  nativeCurrency: { name: 'USDC', symbol: 'USDC', decimals: 18 },
   rpcUrls: {
     default: { http: [`https://rpc.testnet.arc.network/${arcRpcKey}`] },
   },
   blockExplorers: {
-    default: { name: 'Explorer', url: 'https://explorer.arc.testnet.circle.com' },
+    default: { name: 'Arcscan', url: 'https://testnet.arcscan.app' },
   },
   testnet: true,
 } as const satisfies Chain;


### PR DESCRIPTION
Three real chain-configuration bugs that affect any developer forking this sample:

### 1. `lib/chain-config.ts` — wrong native token symbol

\`\`\`diff
 export const NATIVE_TOKENS: Record<string, string> = {
-  arcTestnet: "ARC",
+  arcTestnet: "USDC",
   avalancheFuji: "AVAX",
   baseSepolia: "ETH",
 };
\`\`\`

There is no "ARC" token. Arc's documented core property is **USDC is the native gas token** (see Circle skills [`use-arc/SKILL.md`](https://github.com/circlefin/skills/blob/master/plugins/circle/skills/use-arc/SKILL.md): *"Arc is Circle's blockchain where USDC is the native gas token"*).

This value flows directly into three user-visible error messages in `components/transfer-form.tsx` (lines 79, 81, 83, 92, 94, 96, 97), telling users to acquire a non-existent "ARC" token to pay gas. A new user hitting the gas-insufficient path is directed to find "ARC" on Arc Testnet, which doesn't exist — they should be sent to the [Circle Faucet](https://faucet.circle.com) to get USDC.

### 2. `lib/circle/gateway-sdk.ts` — wrong native decimals

\`\`\`diff
- nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+ nativeCurrency: { name: 'USDC', symbol: 'USDC', decimals: 18 },
\`\`\`

Arc's native gas token uses **18 decimals** (like ETH on other EVM chains), not 6. ERC-20 USDC at `0x3600...` has 6 decimals as a view, but the chain-level `nativeCurrency.decimals` in a viem/wagmi `Chain` definition refers to native gas, which is 18 on Arc. This is explicitly documented in [`use-arc/SKILL.md`](https://github.com/circlefin/skills/blob/master/plugins/circle/skills/use-arc/SKILL.md):

> "Dual decimals: Native gas uses 18 decimals (like ETH on other chains). ERC-20 USDC uses 6 decimals. Mixing these up will produce incorrect amounts."

Empirical confirmation: the canonical `Chain` definition in `circlefin/arc-commerce/lib/wagmi/config.ts` uses `decimals: 18`. The current value of 6 causes viem/wagmi balance display to be off by a factor of `10^12` — a 1.0 USDC balance shows as `1,000,000,000,000` in any component that reads `formatEther`/`formatUnits` against this `nativeCurrency`.

### 3. `lib/circle/gateway-sdk.ts` — broken block explorer URL

\`\`\`diff
- default: { name: 'Explorer', url: 'https://explorer.arc.testnet.circle.com' },
+ default: { name: 'Arcscan', url: 'https://testnet.arcscan.app' },
\`\`\`

`explorer.arc.testnet.circle.com` returns HTTP 000 (DNS does not resolve). The canonical Arc Testnet explorer is `testnet.arcscan.app` (referenced in `circlefin/skills/use-arc/SKILL.md`, `circlefin/arc-fintech/lib/constants/block-explorers.ts`, and `circlefin/arc-commerce/components/wallet/network-indicator.tsx`).

\`\`\`bash
$ curl -sI -o /dev/null -w "%{http_code}\n" "https://explorer.arc.testnet.circle.com"
000
$ curl -sI -o /dev/null -w "%{http_code}\n" "https://testnet.arcscan.app"
200
\`\`\`

Any "View on Explorer" link rendered from this chain config currently 404s.

---

These are the same kind of chain-config inheritance bugs `circlefin/arc-fintech` carries (filing a separate PR there). Fixing the sample apps prevents the bugs from propagating into every downstream fork that uses these as templates.