### PR TITLE
fix: move req.json() inside try/catch to handle invalid JSON body

### DIFF
--- a/app/api/gateway/transfer/route.ts
+++ b/app/api/gateway/transfer/route.ts
@@ -40,10 +40,14 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { sourceChain, destinationChain, amount, recipientAddress } =
-    await req.json();
+  let sourceChain: string | undefined;
+  let destinationChain: string | undefined;
+  let amount: string | undefined;
+  let recipientAddress: string | undefined;
 
   try {
+    ({ sourceChain, destinationChain, amount, recipientAddress } =
+      await req.json());
     if (!sourceChain || !destinationChain || !amount) {
       return NextResponse.json(
         {
@@ -200,6 +204,10 @@ export async function POST(req: NextRequest) {
       recipient,
     });
   } catch (error: any) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
     console.error("Error in transfer:", error);
 
     // Check if this is an insufficient gas error


### PR DESCRIPTION
## Problem

In `app/api/gateway/transfer/route.ts`, the `req.json()` destructuring happens **before** the try block starts at line 46:

```ts
const { sourceChain, destinationChain, amount, recipientAddress } =
  await req.json();

try {
  // ...
}
```

This means:
- Invalid JSON in the request body throws an uncaught `SyntaxError`, producing an unhandled 500 instead of a proper 400
- The variables are referenced in the catch block (lines 241-244 for the failed-transaction logger) where they may be undefined

## Fix

```diff
- const { sourceChain, destinationChain, amount, recipientAddress } =
-   await req.json();
+ let sourceChain: string | undefined;
+ let destinationChain: string | undefined;
+ let amount: string | undefined;
+ let recipientAddress: string | undefined;
 
  try {
+   ({ sourceChain, destinationChain, amount, recipientAddress } =
+     await req.json());
```

And at the top of catch:
```ts
if (error instanceof SyntaxError) {
  return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
}
```

The `SyntaxError` check is intentionally first — before `console.error` and the `INSUFFICIENT_GAS` check — so malformed-body errors never get logged as unexpected transfer failures.

## Impact

- **Correctness:** Malformed JSON returns proper 400 instead of unhandled 500
- **Risk:** Low — variables remain accessible in catch block via outer scope
- **Other routes checked:** `balance/route.ts` and `deposit/route.ts` already call `req.json()` inside their try blocks, no changes needed