### PR TITLE
docs: fix typo and step 3 rendering in arc-multichain-wallet README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A sample application demonstrating how to build optimal USDC interoperability UX for wallets using Arc and Circle Gateway. This app showcases unified balance management, deposits, and cross-chain transfers across multiple EVM chains using Next.js and Supabase.
 
-<img width="830" height="658" alt="Interface for depositing to and transfering from a Gateway balance" src="public/screenshot.png" />
+<img width="830" height="658" alt="Interface for depositing to and transferring from a Gateway balance" src="public/screenshot.png" />
 
 ## Prerequisites
 
@@ -40,6 +40,7 @@ A sample application demonstrating how to build optimal USDC interoperability UX
    ```
 
 3. Set up Supabase (Local)
+   
    This project uses **local Supabase** via Docker for development:
 
    ```bash


### PR DESCRIPTION
Fix a typo and broken rendering in the README.

Changes:
- README.md: `"transfering"` → `"transferring"` in image alt text
- README.md: add blank line after step 3 heading to fix rendering

Test plan
Documentation-only change; no code paths affected.